### PR TITLE
SensorDB Firmware Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,5 +93,4 @@ venv38/
 examples/*.csv
 tests/auth_token.json
 examples/auth_token.json
-
-./pybluemo/auth_token.json
+pybluemo/auth_token.json

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ venv38/
 examples/*.csv
 tests/auth_token.json
 examples/auth_token.json
+
+./pybluemo/auth_token.json

--- a/examples/sensordb_client_config.json
+++ b/examples/sensordb_client_config.json
@@ -4,5 +4,6 @@
   "CognitoPoolId": "",
   "CognitoPoolRegion": "",
   "CognitoClientId": "",
-  "SensorDbApiUrl": ""
+  "SensorDbApiUrl": "",
+  "S3DownloadsBucket": ""
 }


### PR DESCRIPTION
Adds methods to the SensorDbClient that can access current firmware settings, update said settings when a new firmware is pushed, upload firmware files to S3 for download, and add a firmware version to the DynamoDB that can be viewed through the SensorDB web UI.